### PR TITLE
Handle fetch errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A command line tool for fetching bible passages from biblegateway.com.
 
+If fetching from the internet fails, the script prints an error message and exits.
+
 ## Prerequisites
 
 [Beautiful Soup 4](http://www.crummy.com/software/BeautifulSoup/), [Requests](http://docs.python-requests.org/en/latest/), and [Unidecode](https://pypi.python.org/pypi/Unidecode/) are required to run bible-fetch.

--- a/bible
+++ b/bible
@@ -46,9 +46,19 @@ def parse_args():
 
 def get_soup(query, version):
     query = urllib.parse.quote_plus(query)
-    r = requests.get(
+    url = (
         "https://www.biblegateway.com/passage/?search=" + query + "&version=" + version
     )
+    try:
+        r = requests.get(url)
+        if r.status_code >= 400:
+            print(
+                f"Error fetching passage: HTTP {r.status_code}", file=sys.stderr
+            )
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error fetching passage: {e}", file=sys.stderr)
+        sys.exit(1)
     return BeautifulSoup(r.text, "html.parser")
 
 


### PR DESCRIPTION
## Summary
- print an error and exit if online fetch fails
- note error output for failed fetches in README

## Testing
- `python3 -m py_compile bible`
- `pip install beautifulsoup4 requests unidecode` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6883955322ac83239141d2d3273da6bc